### PR TITLE
Convert rasters to Short so no overflow.

### DIFF
--- a/geotrellis/src/main/scala/Model.scala
+++ b/geotrellis/src/main/scala/Model.scala
@@ -5,6 +5,17 @@ import geotrellis.source._
 import geotrellis.raster.op.local.RasterReducer
 
 object Model {
+  private val reducer =
+    new RasterReducer({ (i1:Int, i2:Int) =>
+      if(isNoData(i1)) { i2 }
+      else if(isNoData(i2)) { i1 }
+      else { i1 + i2 }
+    })({ (d1: Double, d2: Double) =>
+      if(isNoData(d1)) { d2 }
+      else if(isNoData(d2)) { d1 }
+      else { d1 + d2 }
+    })
+
   def weightedOverlay(layers:Iterable[String], 
                       weights:Iterable[Int], 
                       rasterExtent:Option[RasterExtent]): RasterSource = {
@@ -17,19 +28,8 @@ object Model {
               case Some(re) => RasterSource(layer, re)
               case None => RasterSource(layer)
             }
-          rs.localMultiply(weight)
+          rs.convert(TypeShort).localMultiply(weight)
         }
-
-    val reducer =
-      new RasterReducer({ (i1:Int, i2:Int) =>
-        if(isNoData(i1)) { i2 }
-        else if(isNoData(i2)) { i1 }
-        else { i1 + i2 }
-      })({ (d1: Double, d2: Double) =>
-        if(isNoData(d1)) { d2 }
-        else if(isNoData(d2)) { d1 }
-        else { d1 + d2 }
-      })
 
     weightedRasters.toList match {
       case head :: List() =>


### PR DESCRIPTION
Also pulled RasterReducer out into a private val since we can reuse the same one for each weightedOverlay call.

Fixes #23
